### PR TITLE
Fix arm64 macOS installer location for R 4.6.0+

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Add P3M support for Ubuntu 26.04.
 
+* Fix arm64 macOS installer location for R 4.6.0 and later. CRAN moved
+  arm64 binaries from `big-sur-arm64/` to `sonoma-arm64/` for R 4.6.0,
+  raising the minimum macOS to Sonoma (14).
+
 # 2.4.12
 
 * Add Ubuntu 26.04 support.

--- a/lib/resolve-os-mac.js
+++ b/lib/resolve-os-mac.js
@@ -28,8 +28,11 @@ function mac_url(version, arch) {
     } else if (arch == "arm64") {
         if (semver.lt(version, "4.1.0")) {
             throw new Error("No arm64 macOS installers are available for R versions before 4.1.0.");
+        } else if (semver.lt(version, "4.6.0")) {
+            return "https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-" + version + "-arm64.pkg";
+        } else {
+            return "https://cran.rstudio.com/bin/macosx/sonoma-arm64/base/R-" + version + "-arm64.pkg";
         }
-        return "https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-" + version + "-arm64.pkg";
     }
 }
 

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -11,7 +11,7 @@ env('NICK',    'https://svn.r-project.org/R/tags/R-%s/VERSION-NICK');
 env('MACOS_X86_64', 'https://cran.rstudio.com/bin/macosx/base/R-%s.pkg');
 env('MACOS2_X86_64', 'https://cran.rstudio.com/bin/macosx/big-sur-x86_64/base/R-%s-x86_64.pkg');
 env('MACOS_ARM64', 'https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-%s-arm64.pkg');
-env('MACOS2_ARM64', 'https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-%s-arm64.pkg');
+env('MACOS2_ARM64', 'https://cran.rstudio.com/bin/macosx/sonoma-arm64/base/R-%s-arm64.pkg');
 env('TARBALL', 'https://cran.rstudio.com/src/base/R-4/R-%s.tar.gz');
 env('WIN',     'https://cran.rstudio.com/bin/windows/base/R-%s-win.exe');
 env('WIN_ARM64', 'https://github.com/r-hub/R/releases/download/v%s/R-%s-aarch64.exe');

--- a/test/available.js
+++ b/test/available.js
@@ -251,9 +251,9 @@ test.serial('available mac arm64 oldest release is 4.1.0', async t => {
     mockSvnBranches();
     mockSvnR46Branch();
     mockSvnTrunk();
-    // arm64 release HEAD
+    // arm64 release HEAD (sonoma-arm64 from R 4.6.0 onwards)
     nock('https://cran.rstudio.com')
-        .head('/bin/macosx/big-sur-arm64/base/R-4.5.3-arm64.pkg').reply(200);
+        .head('/bin/macosx/sonoma-arm64/base/R-4.5.3-arm64.pkg').reply(200);
     // arm64 next HEAD (same URL as x86_64 next but for arm64)
     nock('https://mac.cran.dev')
         .head('/sonoma/last-success/R-4.6-branch-arm64.pkg').reply(200);

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -221,7 +221,7 @@ test.serial('resolve mac x86_64 returns big-sur URL for 4.3+', async t => {
     t.is(r.url, 'https://cran.rstudio.com/bin/macosx/big-sur-x86_64/base/R-4.5.0-x86_64.pkg');
 });
 
-test.serial('resolve mac arm64 returns arm64 URL', async t => {
+test.serial('resolve mac arm64 returns big-sur URL for 4.1.0 to 4.5.x', async t => {
     mockSvnTags();
     const r = await resolve('4.5.0', 'mac', 'arm64', false);
     t.is(r.url, 'https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-4.5.0-arm64.pkg');


### PR DESCRIPTION
## Summary

CRAN moved arm64 macOS binaries from `big-sur-arm64/` to `sonoma-arm64/` starting with R 4.6.0, raising the minimum macOS version to Sonoma (14). This left the API returning 404 URLs for R 4.6.0 arm64 and falling back to R 4.5.3 for `release/macos/arm64`.

## Reproducer (current behaviour)

```bash
$ curl -s "https://api.r-hub.io/rversions/resolve/4.6.0/macos/arm64"
# returns: https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-4.6.0-arm64.pkg

$ curl -sI "https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-4.6.0-arm64.pkg"
HTTP/2 404

$ curl -sI "https://cran.rstudio.com/bin/macosx/sonoma-arm64/base/R-4.6.0-arm64.pkg"
HTTP/2 200
```

`release/macos/arm64` resolves to **4.5.3** instead of 4.6.0:

```bash
$ curl -s "https://api.r-hub.io/rversions/resolve/release/macos/arm64"
# returns version 4.5.3 with a big-sur-arm64 URL

$ curl -s "https://api.r-hub.io/rversions/resolve/release/macos"
# returns version 4.6.0 (Intel)
```

## Changes

Mirrors the previous transition for x86_64 in 1d823d7 ("Fix for new macOS installer location"):

- `lib/urls.js` — point `MACOS2_ARM64` at `sonoma-arm64/`. `MACOS_ARM64` keeps the `big-sur-arm64/` path for older releases.
- `lib/resolve-os-mac.js` — extend the arm64 branch of `mac_url()` with a `< 4.6.0` cutoff, matching the existing tiered pattern used for x86_64.
- `test/available.js`, `test/resolve.js` — update arm64 mock URL and rename test for the pre-4.6.0 path.
- `NEWS.md` — entry under 2.4.13.

## Verification

- `npm test` — all 123 tests pass.
- Sanity-checked target URLs against real CRAN: both `sonoma-arm64/.../R-4.6.0-arm64.pkg` and `big-sur-arm64/.../R-4.5.3-arm64.pkg` return 200.

## Context

Reported at r-hub/rversions#43. Filed downstream notice at r-lib/actions#1053 — `setup-r@v2` follows whatever URL this API returns, so on `macos-latest` (Apple Silicon) it has been silently installing R 4.5.3 instead of R 4.6.0 since the 4.6.0 release on 2026-04-24.